### PR TITLE
fix: formatting of composable cli command

### DIFF
--- a/docs/developer-tools/composable-cli/commands.mdx
+++ b/docs/developer-tools/composable-cli/commands.mdx
@@ -23,17 +23,22 @@ Composable CLI accelerates your time to market by providing the following featur
 If you've installed Composable CLI globally you can run all commands using your package manager:
 
 <Tabs>
-<TabItem title="Alias" value="alias">
+<TabItem value="alias" label="Alais">
+
 ```bash
 ep [COMMAND] --[FLAG]
 ```
+
 </TabItem>
-<TabItem title="Standard" value="standard">
+<TabItem value="standard" label="Standard">
+
 ```bash
 composable-cli [COMMAND] --[FLAG]
 ```
+
 </TabItem>
 </Tabs>
+
 ---
 
 ## Command reference


### PR DESCRIPTION
## Scope

Fix the formatting of the compsable cli command syntax

## Testing

Navigate to /docs/developer-tools/composable-cli/commands#command-syntax and look at the tabed section, it should be working as expected