### PR TITLE
Update message regarding 200 OK responses

### DIFF
--- a/guides/Getting-Started/filtering.md
+++ b/guides/Getting-Started/filtering.md
@@ -260,6 +260,36 @@ An incorrectly formatted filter or an unsupported operator returns a `400` respo
 }
 ```
 
+:::note
+When a query with a filter returns no matching results, the API will respond with the following: HTTP Status Code: 200 OK
+This indicates that the request was successful, even if no records match the filter criteria.
+	- Response Body:
+```json
+{
+  "meta": {
+    "page": {
+      "limit": 25,
+      "offset": 0,
+      "current": 1,
+      "total": 0
+    },
+    "results": {
+      "total": 0
+    }
+  },
+  "data": [],
+  "links": {
+    "current": "{base_url}/example/?filter=eq(name,Elastic)&page[offset]=0&page[limit]=25",
+    "first": "{base_url}/example/?filter=eq(name,Elastic)&page[offset]=0&page[limit]=25",
+    "last": "{base_url}/example/?filter=eq(name,Elastic)&page[offset]=0&page[limit]=25",
+    "next": "null",
+    "prev": "null"
+  }
+}
+```
+The empty data array signifies that no records were found.
+:::
+
 ### Performance
 
 Filtered queries may be less performant than non-filtered queries, especially at scale (either with high


### PR DESCRIPTION
Updated Message Regarding 200 OK Responses:
We want to clarify what customers can expect when using filters. When a filter is applied, a 200 OK response indicates a successful request, even if no results match the criteria. In such cases, the response will contain an empty data set. This ensures users know their request was processed correctly, but no matching records were found.